### PR TITLE
Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,12 @@
     "require": {
         "laravel/legacy-factories": "^1.3",
         "nl.idaas/openid-server": "^0.4.2",
-        "illuminate/http": "^10.0|^11.0",
-        "illuminate/contracts": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/auth": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "laravel/passport": "^10.0|^11.0|^12"
+        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/auth": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "laravel/passport": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added Laravel 12 support by updating dependency constraints in `composer.json`
- Extended `illuminate/http`, `illuminate/contracts`, `illuminate/support`, `illuminate/auth`, and `illuminate/database` to accept Laravel 12 versions (`^12.0`)
- Updated `laravel/passport` compatibility to explicitly support versions 10, 11, and 12

## Contributor Changes

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Karl Monson | 6 | 6 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->