### PR TITLE
feat/laravel_12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
     "require": {
         "laravel/legacy-factories": "^1.3",
         "nl.idaas/openid-server": "dev-develop",
-        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/auth": "^10.0|^11.0|^12.0|^13.0",
-        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
-        "laravel/passport": "^10.0|^11.0|^12.0|^13.0"
+        "illuminate/http": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/auth": "^11.0|^12.0|^13.0",
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "laravel/passport": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
     "require": {
         "laravel/legacy-factories": "^1.3",
         "nl.idaas/openid-server": "dev-develop",
-        "illuminate/http": "^10.0|^11.0|^12.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/auth": "^10.0|^11.0|^12.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "laravel/passport": "^10.0|^11.0|^12.0"
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/auth": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+        "laravel/passport": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,12 @@
     "require": {
         "laravel/legacy-factories": "^1.3",
         "nl.idaas/openid-server": "dev-develop",
-        "illuminate/http": "^10.0|^11.0",
-        "illuminate/contracts": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0",
-        "illuminate/auth": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "laravel/passport": "^10.0|^11.0|^12"
+        "illuminate/http": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/auth": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "laravel/passport": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Updated `composer.json` to widen supported Illuminate versions for `illuminate/http`, `illuminate/contracts`, `illuminate/support`, `illuminate/auth`, and `illuminate/database` to `^11.0|^12.0|^13.0` (including Laravel 12 compatibility)
- Updated `laravel/passport` compatibility to `^11.0|^12.0|^13.0` (including Laravel 12 support)

## Contributor Statistics

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Karl Monson | 60 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->